### PR TITLE
Update class.ems_rest.php

### DIFF
--- a/livewhale-client-modules/ems/includes/class.ems_rest.php
+++ b/livewhale-client-modules/ems/includes/class.ems_rest.php
@@ -134,6 +134,10 @@ if ($response=$this->getResponse('/bookings/actions/search', $params, $payload))
 		};
 		foreach($response['results'] as $booking) {
 			if (!empty($booking)) { // sanitize result data
+				if ($booking['room']['isAssociatedRoom'] == '1') {
+					// skip isAssociatedRoom=1 bookings, they show up twice and the isAssociatedRoom=0 has the more detailed room info
+					continue;
+				};
 				foreach($booking as $key=>$val) {
 					switch($key) {
 						case 'id':


### PR DESCRIPTION
Testing on Berkeley dev – skip isAssociatedRoom records corresponding to duplicate (and less detailed) EMS results.